### PR TITLE
has-transform-position bugfixes

### DIFF
--- a/tests/fake_furnace/test_fake_furnace.py
+++ b/tests/fake_furnace/test_fake_furnace.py
@@ -19,6 +19,7 @@ def test_ramp():
     c = yaqc.Client(39426)
     c.set_ramp_time(0)
     c.set_position(0)
+    time.sleep(0.1)
     assert c.get_position() == 0
     c.set_ramp_time(1)
     c.set_position(100)

--- a/tests/fake_has_transformed_position/config.toml
+++ b/tests/fake_has_transformed_position/config.toml
@@ -1,4 +1,13 @@
-[fake-transformed]
+[fake-transformed1]
 port=38001
 velocity=100.0
+factor=2.0
 limits=[1.0,4.0]
+
+[fake-transformed2]
+port=38002
+velocity=100.0
+factor=-1.0
+limits=[-1.0,-4.0]
+native_limits=[0.0,3.0]
+

--- a/tests/fake_has_transformed_position/test_fake_has_transformed_position.py
+++ b/tests/fake_has_transformed_position/test_fake_has_transformed_position.py
@@ -31,6 +31,8 @@ def test_limits():
         config = tomli.loads(c.get_config())
 
         limits = c.get_limits()
+        lims2 = list(map(c.to_transformed, c.get_native_limits()))
+        assert np.isclose(limits, lims2).all()
 
         for setpoint, actual in zip(
             [limits[0] - 0.5, 0.5 * sum(limits), limits[1] + 0.5],
@@ -39,10 +41,9 @@ def test_limits():
             c.set_position(setpoint)
             time.sleep(0.10)
             assert np.isclose(c.get_position(), actual)
+            assert np.isclose(c.get_destination(), actual)
             assert np.isclose(c.get_native_position(), c.to_native(actual))
-
-        lims2 = list(map(c.to_transformed, c.get_native_limits()))
-        assert np.isclose(limits, lims2).all()
+            assert np.isclose(c.get_native_destination(), c.to_native(actual))
 
 
 @testing.run_daemon_entry_point("fake-has-transformed-position", config=config)

--- a/tests/fake_has_transformed_position/test_fake_has_transformed_position.py
+++ b/tests/fake_has_transformed_position/test_fake_has_transformed_position.py
@@ -2,8 +2,8 @@ import pathlib
 import subprocess
 import sys
 import time
-import math
 import numpy as np
+import toml
 
 import pytest
 
@@ -15,74 +15,53 @@ from yaqd_core import testing
 config = pathlib.Path(__file__).parent / "config.toml"
 
 
-def to_native(t, nr=1):
-    #  n = 0.5*t - 1
-    rel = 0.5 * t
-    return rel + nr
-
-
-def to_transformed(n, nr=1):
-    #  t = 2*(n - 1)
-    rel = n - nr
-    return 2 * rel
-
-
 @testing.run_daemon_entry_point("fake-has-transformed-position", config=config)
 def test_transform():
     c = yaqc.Client(38001)
     c.set_native_reference(1.0)
     val = 3.0
-    assert np.isclose(c.to_native(val), 2.5)
     bb = c.to_transformed(c.to_native(val))
     assert np.isclose(val, bb)
 
 
 @testing.run_daemon_entry_point("fake-has-transformed-position", config=config)
 def test_limits():
-    c = yaqc.Client(38001)
+    for port in [38001, 38002]:
+        c = yaqc.Client(port)
+        config = toml.loads(c.get_config())
 
-    assert np.isclose(c.get_limits(), [1.0, 4.0]).all()
-    assert np.isclose(c.get_native_limits(), [1.5, 3]).all()
+        limits = c.get_limits()
 
-    val = 3.0
-    c.set_position(val)
-    time.sleep(0.10)
-    assert np.isclose(c.get_position(), val)
-    assert np.isclose(c.get_native_position(), to_native(val))
+        for setpoint, actual in zip(
+            [limits[0]-0.5, 0.5*sum(limits), limits[1]+0.5],
+            [limits[0], 0.5*sum(limits), limits[1]]   
+        ):
+            c.set_position(setpoint)
+            time.sleep(0.10)
+            assert np.isclose(c.get_position(), actual)
+            assert np.isclose(c.get_native_position(), c.to_native(actual))
 
-    val = 0.5
-    c.set_position(val)
-    time.sleep(0.10)
-    assert np.isclose(c.get_position(), 1.0)
-
-    val = 4.5
-    c.set_position(val)
-    time.sleep(0.10)
-    assert np.isclose(c.get_position(), 4.0)
-
-    lims1 = c.get_limits()
-    lims2 = c.get_native_limits()
-    A = [c.to_transformed(lims2[0]), c.to_transformed(lims2[1])]
-    assert np.isclose(lims1[0], 1.0)
-    assert np.isclose(lims1[1], 4.0)
-    assert np.isclose(lims1[0], A[0])
-    assert np.isclose(lims1[1], A[1])
+        lims2 = list(map(c.to_transformed, c.get_native_limits()))
+        assert np.isclose(limits, lims2).all()
 
 
 @testing.run_daemon_entry_point("fake-has-transformed-position", config=config)
 def test_change_native_reference():
-    c = yaqc.Client(38001)
+    for port in [38001, 38002]:
+        c = yaqc.Client(port)
+        factor = toml.loads(c.get_config())["factor"]
 
-    t_pos = 2
-    c.set_native_reference(1)
-    c.set_position(t_pos)
-    time.sleep(0.1)
+        midrange = 0.5 * sum(c.get_limits())
 
-    native_position = c.get_native_position()
-    c.set_native_reference(c.get_native_reference() + 1)
+        c.set_native_reference(1)
+        c.set_position(midrange)
+        time.sleep(0.1)
+        native_position = c.get_native_position()
+        assert np.isclose(native_position, c.to_native(midrange))
+        c.set_native_reference(1.5)
 
-    assert native_position == c.get_native_position()
-    assert c.get_position() == to_transformed(to_native(t_pos) - 1)
+        assert np.isclose(native_position, c.get_native_position())
+        assert np.isclose(c.get_position(), c.to_transformed(c.to_native(midrange) - 0.5))
 
 
 @testing.run_daemon_entry_point("fake-has-transformed-position", config=config)
@@ -95,3 +74,10 @@ def test_set_relative():
     time.sleep(0.1)
 
     assert np.isclose(destination, initial + 1.0)
+
+
+if __name__ == "__main__":
+    test_change_native_reference()
+    test_limits()
+    test_set_relative()
+    test_transform()

--- a/tests/fake_has_transformed_position/test_fake_has_transformed_position.py
+++ b/tests/fake_has_transformed_position/test_fake_has_transformed_position.py
@@ -15,6 +15,18 @@ from yaqd_core import testing
 config = pathlib.Path(__file__).parent / "config.toml"
 
 
+def to_native(t, nr=1):
+    #  n = 0.5*t - 1
+    rel = 0.5 * t
+    return rel + nr
+
+
+def to_transformed(n, nr=1):
+    #  t = 2*(n - 1)
+    rel = n - nr
+    return 2 * rel
+
+
 @testing.run_daemon_entry_point("fake-has-transformed-position", config=config)
 def test_transform():
     c = yaqc.Client(38001)
@@ -28,10 +40,15 @@ def test_transform():
 @testing.run_daemon_entry_point("fake-has-transformed-position", config=config)
 def test_limits():
     c = yaqc.Client(38001)
+
+    assert np.isclose(c.get_limits(), [1., 4.]).all()
+    assert np.isclose(c.get_native_limits(), [1.5, 3]).all()
+
     val = 3.0
     c.set_position(val)
     time.sleep(0.10)
     assert np.isclose(c.get_position(), val)
+    assert np.isclose(c.get_native_position(), to_native(val))
 
     val = 0.5
     c.set_position(val)
@@ -50,3 +67,45 @@ def test_limits():
     assert np.isclose(lims1[1], 4.0)
     assert np.isclose(lims1[0], A[0])
     assert np.isclose(lims1[1], A[1])
+
+
+@testing.run_daemon_entry_point("fake-has-transformed-position", config=config)
+def test_change_native_reference():
+    c = yaqc.Client(38001)
+
+    t_pos = 2
+    c.set_native_reference(1)
+    c.set_position(t_pos)
+    time.sleep(0.1)
+
+    try:
+        native_position = c.get_native_position()
+        c.set_native_reference(c.get_native_reference() + 1)
+
+        assert native_position == c.get_native_position()
+        assert c.get_position() == to_transformed(to_native(t_pos) - 1)
+    finally:
+        c.set_native_reference(1)
+
+
+@testing.run_daemon_entry_point("fake-has-transformed-position", config=config)
+def test_set_relative():
+    c = yaqc.Client(38001)
+    print(c.get_limits())
+    c.set_position(c.get_limits()[0])
+    time.sleep(0.1)
+    c.set_relative(1.)
+    time.sleep(0.1)
+    try:
+        assert np.isclose(c.get_position(), 2.)
+    except AssertionError as e:
+        print(c.get_position())
+        raise e
+
+
+if __name__ == "__main__":
+    # test_transform()
+    # test_limits()
+    # test_change_native_reference()
+    # test_native_limits()
+    test_set_relative()

--- a/tests/fake_has_transformed_position/test_fake_has_transformed_position.py
+++ b/tests/fake_has_transformed_position/test_fake_has_transformed_position.py
@@ -41,7 +41,7 @@ def test_transform():
 def test_limits():
     c = yaqc.Client(38001)
 
-    assert np.isclose(c.get_limits(), [1., 4.]).all()
+    assert np.isclose(c.get_limits(), [1.0, 4.0]).all()
     assert np.isclose(c.get_native_limits(), [1.5, 3]).all()
 
     val = 3.0
@@ -89,10 +89,9 @@ def test_change_native_reference():
 def test_set_relative():
     c = yaqc.Client(38001)
     c.set_position(c.get_limits()[0])
-    initial = c.get_position() 
+    initial = c.get_position()
     time.sleep(0.1)
-    destination = c.set_relative(1.)
+    destination = c.set_relative(1.0)
     time.sleep(0.1)
 
-    assert np.isclose(destination, initial + 1.)
-
+    assert np.isclose(destination, initial + 1.0)

--- a/tests/fake_has_transformed_position/test_fake_has_transformed_position.py
+++ b/tests/fake_has_transformed_position/test_fake_has_transformed_position.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 import time
 import numpy as np
-import toml
+import tomli
 
 import pytest
 
@@ -28,7 +28,7 @@ def test_transform():
 def test_limits():
     for port in [38001, 38002]:
         c = yaqc.Client(port)
-        config = toml.loads(c.get_config())
+        config = tomli.loads(c.get_config())
 
         limits = c.get_limits()
 
@@ -49,7 +49,7 @@ def test_limits():
 def test_change_native_reference():
     for port in [38001, 38002]:
         c = yaqc.Client(port)
-        factor = toml.loads(c.get_config())["factor"]
+        factor = tomli.loads(c.get_config())["factor"]
 
         midrange = 0.5 * sum(c.get_limits())
 

--- a/tests/fake_has_transformed_position/test_fake_has_transformed_position.py
+++ b/tests/fake_has_transformed_position/test_fake_has_transformed_position.py
@@ -78,34 +78,21 @@ def test_change_native_reference():
     c.set_position(t_pos)
     time.sleep(0.1)
 
-    try:
-        native_position = c.get_native_position()
-        c.set_native_reference(c.get_native_reference() + 1)
+    native_position = c.get_native_position()
+    c.set_native_reference(c.get_native_reference() + 1)
 
-        assert native_position == c.get_native_position()
-        assert c.get_position() == to_transformed(to_native(t_pos) - 1)
-    finally:
-        c.set_native_reference(1)
+    assert native_position == c.get_native_position()
+    assert c.get_position() == to_transformed(to_native(t_pos) - 1)
 
 
 @testing.run_daemon_entry_point("fake-has-transformed-position", config=config)
 def test_set_relative():
     c = yaqc.Client(38001)
-    print(c.get_limits())
     c.set_position(c.get_limits()[0])
+    initial = c.get_position() 
     time.sleep(0.1)
-    c.set_relative(1.)
+    destination = c.set_relative(1.)
     time.sleep(0.1)
-    try:
-        assert np.isclose(c.get_position(), 2.)
-    except AssertionError as e:
-        print(c.get_position())
-        raise e
 
+    assert np.isclose(destination, initial + 1.)
 
-if __name__ == "__main__":
-    # test_transform()
-    # test_limits()
-    # test_change_native_reference()
-    # test_native_limits()
-    test_set_relative()

--- a/yaqd-core/yaqd_core/_has_limits.py
+++ b/yaqd-core/yaqd_core/_has_limits.py
@@ -23,7 +23,7 @@ class HasLimits(HasPosition, IsDaemon):
         return self._joint_limit(self._state["hw_limits"], self._config["limits"])
 
     @classmethod
-    def _joint_limit(self, *limits:List[List[float, float]]):
+    def _joint_limit(self, *limits: List[List[float, float]]):
         mins, maxes = [*zip(*limits)]
         assert all([mini < maxi for mini, maxi in zip(mins, maxes)])
         out = [max(*mins), min(*maxes)]

--- a/yaqd-core/yaqd_core/_has_limits.py
+++ b/yaqd-core/yaqd_core/_has_limits.py
@@ -16,7 +16,7 @@ class HasLimits(HasPosition, IsDaemon):
 
     def get_limits(self) -> List[float]:
         # wrapper for client
-        return self._get_limits(self)
+        return self._get_limits()
 
     def _get_limits(self) -> List[float]:
         # for internal use

--- a/yaqd-core/yaqd_core/_has_limits.py
+++ b/yaqd-core/yaqd_core/_has_limits.py
@@ -23,7 +23,7 @@ class HasLimits(HasPosition, IsDaemon):
         return self._joint_limit(self._state["hw_limits"], self._config["limits"])
 
     @classmethod
-    def _joint_limit(self, *limits):
+    def _joint_limit(self, *limits:List[List[float, float]]):
         mins, maxes = [*zip(*limits)]
         assert all([mini < maxi for mini, maxi in zip(mins, maxes)])
         out = [max(*mins), min(*maxes)]

--- a/yaqd-core/yaqd_core/_has_limits.py
+++ b/yaqd-core/yaqd_core/_has_limits.py
@@ -23,7 +23,7 @@ class HasLimits(HasPosition, IsDaemon):
         return self._joint_limit(self._state["hw_limits"], self._config["limits"])
 
     @classmethod
-    def _joint_limit(self, *limits: List[List[float, float]]):
+    def _joint_limit(self, *limits: List[float]):
         mins, maxes = [*zip(*limits)]
         assert all([mini < maxi for mini, maxi in zip(mins, maxes)])
         out = [max(*mins), min(*maxes)]

--- a/yaqd-core/yaqd_core/_has_limits.py
+++ b/yaqd-core/yaqd_core/_has_limits.py
@@ -36,14 +36,11 @@ class HasLimits(HasPosition, IsDaemon):
 
     def _in_limits(self, position):
         # for internal use
-        self.logger.info(f"checking if position {position} is in limits")
         low, upp = self._get_limits()
         return low <= position <= upp
 
     def set_position(self, position: float) -> None:
-        self.logger.info(f"setting position to {position}")
         if not self._in_limits(position):
-            self.logger.info("out of limits")
             if self._out_of_limits == "closest":
                 low, upp = self._get_limits()
                 if position > upp:

--- a/yaqd-core/yaqd_core/_has_limits.py
+++ b/yaqd-core/yaqd_core/_has_limits.py
@@ -32,7 +32,7 @@ class HasLimits(HasPosition, IsDaemon):
 
     def in_limits(self, position: float) -> bool:
         # client wrapper
-        return self._in_limits(position)        
+        return self._in_limits(position)
 
     def _in_limits(self, position):
         # for internal use

--- a/yaqd-core/yaqd_core/_has_limits.py
+++ b/yaqd-core/yaqd_core/_has_limits.py
@@ -15,13 +15,16 @@ class HasLimits(HasPosition, IsDaemon):
         self._out_of_limits = config["out_of_limits"]
 
     def get_limits(self) -> List[float]:
-        assert self._state["hw_limits"][0] < self._state["hw_limits"][1]
-        config_limits = self._config["limits"]
-        assert config_limits[0] < config_limits[1]
-        out = [
-            max(self._state["hw_limits"][0], config_limits[0]),
-            min(self._state["hw_limits"][1], config_limits[1]),
-        ]
+        return self._joint_limit(self._state["hw_limits"], self._config["limits"])
+
+    def _joint_limit(self, *limits):
+        mins = []
+        maxes = []
+        for limit in limits:
+            assert limit[0] < limit[1]
+            mins.append(limit[0])
+            maxes.append(limit[1])
+        out = [max(mins), min(maxes)]
         assert out[0] < out[1]
         return out
 

--- a/yaqd-core/yaqd_core/_has_transformed_position.py
+++ b/yaqd-core/yaqd_core/_has_transformed_position.py
@@ -57,6 +57,11 @@ class HasTransformedPosition(HasLimits, HasPosition, IsDaemon):
         self.logger.info(f"htp-set-position({position})")
         super().set_position(self.to_native(position))
 
+    def set_relative(self, distance: float) -> float:
+        new = self.to_transformed(self._state["destination"]) + distance
+        self.set_position(new)
+        return new
+
     def get_position(self) -> float:
         position = super().get_position()
         return self.to_transformed(position)
@@ -68,7 +73,7 @@ class HasTransformedPosition(HasLimits, HasPosition, IsDaemon):
         return super().in_limits(self.to_native(position))
 
     def get_limits(self) -> List[float]:
-        return list(map(self.to_transformed, self._get_limits()))
+        return sorted(map(self.to_transformed, self._get_limits()))
 
     # --- setting or returning native coordinates -------------------------------------------------
 

--- a/yaqd-core/yaqd_core/_has_transformed_position.py
+++ b/yaqd-core/yaqd_core/_has_transformed_position.py
@@ -54,7 +54,6 @@ class HasTransformedPosition(HasLimits, HasPosition, IsDaemon):
     # --- methods that send or recieve transformed positions --------------------------------------
 
     def set_position(self, position: float) -> None:
-        self.logger.info(f"htp-set-position({position})")
         super().set_position(self.to_native(position))
 
     def set_relative(self, distance: float) -> float:

--- a/yaqd-core/yaqd_core/_has_transformed_position.py
+++ b/yaqd-core/yaqd_core/_has_transformed_position.py
@@ -6,9 +6,6 @@ from typing import Dict, Any, Optional, List
 from yaqd_core import HasLimits, HasPosition, IsDaemon
 
 
-_joint_limit = HasLimits._joint_limit
-
-
 class HasTransformedPosition(HasLimits, HasPosition, IsDaemon):
     def __init__(
         self, name: str, config: Dict[str, Any], config_filepath: pathlib.Path
@@ -83,7 +80,7 @@ class HasTransformedPosition(HasLimits, HasPosition, IsDaemon):
 
     @property
     def limits(self) -> List[float]:
-        return _joint_limit(
+        return self._joint_limit(
             self._state["hw_limits"],
             sorted(map(self.to_native, self._config["limits"])),
             self._config["native_limits"],
@@ -102,7 +99,7 @@ class HasTransformedPosition(HasLimits, HasPosition, IsDaemon):
         return self._state["position"]
 
     def get_native_destination(self) -> float:
-        return self.to_native(super().get_destination())
+        return self._state["destination"]
 
     def get_native_limits(self) -> List[float]:
         return self.limits

--- a/yaqd-core/yaqd_core/_has_transformed_position.py
+++ b/yaqd-core/yaqd_core/_has_transformed_position.py
@@ -80,7 +80,7 @@ class HasTransformedPosition(HasLimits, HasPosition, IsDaemon):
         limits = [
             self._state["hw_limits"],
             sorted(map(self.to_native, self._config["limits"])),
-            self._config["native_limits"]
+            self._config["native_limits"],
         ]
         return HasLimits._joint_limit(*limits)
 

--- a/yaqd-core/yaqd_core/_has_transformed_position.py
+++ b/yaqd-core/yaqd_core/_has_transformed_position.py
@@ -54,27 +54,17 @@ class HasTransformedPosition(HasLimits, HasPosition, IsDaemon):
     # --- methods for transformed positions -------------------------------------------------------
 
     def get_limits(self) -> List[float]:
-        assert self._state["hw_limits"][0] < self._state["hw_limits"][1]
-        config_limits = self._config["limits"]
-        assert config_limits[0] < config_limits[1]
-        config_native_limits = self._config["native_limits"]
-        assert config_native_limits[0] < config_native_limits[1]
-        out = [
-            max(
-                self._state["hw_limits"][0],
-                config_limits[0],
-                self.to_transformed(config_native_limits[0]),
-            ),
-            min(
-                self._state["hw_limits"][1],
-                config_limits[1],
-                self.to_transformed(config_native_limits[1]),
-            ),
+        limits = [
+            self._state["hw_limits"],
+            self._config["limits"],
+            sorted(map(self.to_transformed, self._config["native_limits"]))
         ]
-        assert out[0] < out[1]
-        return out
+        return super()._joint_limit(limits)
 
     # --- native properties -----------------------------------------------------------------------
+
+    # ddk: it is simpler to keep track of native position
+    # transformed position changes whenever the transform changes
 
     def get_native_reference(self) -> float:
         return self._state["native_reference_position"]

--- a/yaqd-core/yaqd_core/_has_transformed_position.py
+++ b/yaqd-core/yaqd_core/_has_transformed_position.py
@@ -86,7 +86,7 @@ class HasTransformedPosition(HasLimits, HasPosition, IsDaemon):
         return _joint_limit(
             self._state["hw_limits"],
             sorted(map(self.to_native, self._config["limits"])),
-            self._config["native_limits"]
+            self._config["native_limits"],
         )
 
     def get_native_reference(self) -> float:

--- a/yaqd-fakes/yaqd_fakes/_fake_has_transformed_position.py
+++ b/yaqd-fakes/yaqd_fakes/_fake_has_transformed_position.py
@@ -19,6 +19,7 @@ class FakeHasTransformedPosition(HasTransformedPosition):
         # limits should be specified in the config for the fake
         self._velocity = config["velocity"]
         self.set_native_reference(1.0)
+        self.factor  = config["factor"]
 
     def _set_position(self, position: float) -> None:
         pass

--- a/yaqd-fakes/yaqd_fakes/fake-has-transformed-position.avpr
+++ b/yaqd-fakes/yaqd_fakes/fake-has-transformed-position.avpr
@@ -6,6 +6,11 @@
             "origin": "is-daemon",
             "type": "boolean"
         },
+        "factor": {
+            "default": 1.0,
+            "doc": "Scaling factor for transformed position. Specifies transformed steps per native step.",
+            "type": "float"
+        },
         "limits": {
             "default": [
                 -Infinity,

--- a/yaqd-fakes/yaqd_fakes/fake-has-transformed-position.toml
+++ b/yaqd-fakes/yaqd_fakes/fake-has-transformed-position.toml
@@ -17,3 +17,8 @@ conda-forge = "https://anaconda.org/conda-forge/yaqd-fakes"
 type="float"
 default = 1.0
 
+[config.factor]
+type="float"
+doc = "Scaling factor for transformed position. Specifies transformed steps per native step."
+default = 1.0
+


### PR DESCRIPTION
- fixed branch bug where position would be lost when transform parameters (e.g. native_reference) were changed
- fixed bug where limits were oppositely ordered if transformed position had a negative slope wrt native position.
- set_relative gives expected behavior when used with has-transformed-position
- added tests

