### PR TITLE
Implement get_aserial helper function

### DIFF
--- a/yaqd-core/yaqd_core/aserial/_aserial.py
+++ b/yaqd-core/yaqd_core/aserial/_aserial.py
@@ -56,7 +56,7 @@ class ASerial(serial.Serial):
 _serial_objects: Dict[str, ASerial] = {}
 
 
-def get_aserial(  # pylint: disable = W1113:keyword-arg-before-vararg
+def get_aserial(
     port: str,
     baudrate: int = 9600,
     eol: bytes = b"\n",
@@ -64,13 +64,25 @@ def get_aserial(  # pylint: disable = W1113:keyword-arg-before-vararg
 ) -> ASerial:
     """Create a new ASerial object or return already existed one.
 
-    Args:
-        port (str): Serial port identificator, 'COM0' or '/dev/ttyUSB0'
-        baudrate (int, optional): Baud rate of the port. Defaults to 9600.
-        eol (bytes, optional): End of line terminator. Defaults to b"\n".
+    Parameters
+    ----------
+    port: str
+        Serial port identificator, e.g. 'COM0' or '/dev/ttyUSB0'
+        If an matching open port exists, all other arguments are ignored.
+    baudrate: int, optional
+        Baud rate of the port. Defaults to 9600.
+    eol: bytes, optional
+        End of line terminator. Defaults to new-line.
 
-    Returns:
-        ASerial: corresponding ASerial object
+    Other Parameters
+    ----------------
+    **kwargs: `serial.Serial` arguments, optional
+
+
+    Returns
+    -------
+    ASerial
+        Corresponding ASerial object
     """
     if port not in _serial_objects:
         _serial_objects[port] = ASerial(port=port, baudrate=baudrate, eol=eol, **kwargs)

--- a/yaqd-core/yaqd_core/aserial/_aserial.py
+++ b/yaqd-core/yaqd_core/aserial/_aserial.py
@@ -73,7 +73,8 @@ def get_aserial(  # pylint: disable = W1113:keyword-arg-before-vararg
     Returns:
         ASerial: corresponding ASerial object
     """
-    if port in _serial_objects:
-        return _serial_objects[port]
-    else:
-        return ASerial(port=port, baudrate=baudrate, eol=eol, *args, **kwargs)
+    if port not in _serial_objects:
+        _serial_objects[port] = ASerial(
+            port=port, baudrate=baudrate, eol=eol, *args, **kwargs
+        )
+    return _serial_objects[port]

--- a/yaqd-core/yaqd_core/aserial/_aserial.py
+++ b/yaqd-core/yaqd_core/aserial/_aserial.py
@@ -60,7 +60,7 @@ def get_aserial(  # pylint: disable = W1113:keyword-arg-before-vararg
     port: str,
     baudrate: int = 9600,
     eol: bytes = b"\n",
-    *args: Any,
+    /,
     **kwargs: Any,
 ) -> ASerial:
     """Create a new ASerial object or return already existed one.
@@ -74,7 +74,5 @@ def get_aserial(  # pylint: disable = W1113:keyword-arg-before-vararg
         ASerial: corresponding ASerial object
     """
     if port not in _serial_objects:
-        _serial_objects[port] = ASerial(
-            port=port, baudrate=baudrate, eol=eol, *args, **kwargs
-        )
+        _serial_objects[port] = ASerial(port=port, baudrate=baudrate, eol=eol, **kwargs)
     return _serial_objects[port]

--- a/yaqd-core/yaqd_core/aserial/_aserial.py
+++ b/yaqd-core/yaqd_core/aserial/_aserial.py
@@ -1,7 +1,8 @@
-__all__ = ["ASerial"]
-
+__all__ = ["ASerial", "get_aserial"]
 
 import asyncio
+from typing import Any, Dict
+
 import serial  # type: ignore
 
 
@@ -50,3 +51,29 @@ class ASerial(serial.Serial):
         async with self._readlock:
             self.write(data)
             return await self._areadline(size)
+
+
+_serial_objects: Dict[str, ASerial] = {}
+
+
+def get_aserial(  # pylint: disable = W1113:keyword-arg-before-vararg
+    port: str,
+    baudrate: int = 9600,
+    eol: bytes = b"\n",
+    *args: Any,
+    **kwargs: Any,
+) -> ASerial:
+    """Create a new ASerial object or return already existed one.
+
+    Args:
+        port (str): Serial port identificator, 'COM0' or '/dev/ttyUSB0'
+        baudrate (int, optional): Baud rate of the port. Defaults to 9600.
+        eol (bytes, optional): End of line terminator. Defaults to b"\n".
+
+    Returns:
+        ASerial: corresponding ASerial object
+    """
+    if port in _serial_objects:
+        return _serial_objects[port]
+    else:
+        return ASerial(port=port, baudrate=baudrate, eol=eol, *args, **kwargs)

--- a/yaqd-core/yaqd_core/aserial/_aserial.py
+++ b/yaqd-core/yaqd_core/aserial/_aserial.py
@@ -60,7 +60,6 @@ def get_aserial(  # pylint: disable = W1113:keyword-arg-before-vararg
     port: str,
     baudrate: int = 9600,
     eol: bytes = b"\n",
-    /,
     **kwargs: Any,
 ) -> ASerial:
     """Create a new ASerial object or return already existed one.

--- a/yaqd-fakes/CHANGELOG.md
+++ b/yaqd-fakes/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- aserial.get_aserial(), helper function that caches already created serial objects
+
 ## [2023.6.0]
 
 ### Added


### PR DESCRIPTION
This PR adds `get_aserial` helper function that tries to use already created `ASerial` objects.