### PR TITLE
Rework unpacker to use the null termination of messages

### DIFF
--- a/yaqc/yaqc/_socket.py
+++ b/yaqc/yaqc/_socket.py
@@ -65,6 +65,7 @@ class Socket:
         self._write(request)
         self._write_metadata()
         self._write_method_name("")
+        self._write_terminator()
         # read response
         response = self._read(handshake_response)
         self._read({"type": "map", "values": "bytes"})

--- a/yaqd-core/yaqd_core/avrorpc/unpacker.py
+++ b/yaqd-core/yaqd_core/avrorpc/unpacker.py
@@ -34,9 +34,9 @@ class Unpacker:
             msg,
         )
         message_name = self._read_object("string", msg)
-        if message_name != "" and self.protocol["messages"][
-            message_name
-        ].get("request", []):
+        if message_name != "" and self.protocol["messages"][message_name].get(
+            "request", []
+        ):
             parameters = self._read_parameters(message_name, msg)
 
         print(f"Identifieed {message_name=} with {parameters=}")
@@ -56,13 +56,13 @@ class Unpacker:
         while data:
             print(data, self._remaining, len(data))
             if self._remaining:
-                written = self._buf.write(data[:self._remaining])
+                written = self._buf.write(data[: self._remaining])
                 data = data[written:]
                 self._remaining -= written
             if data:
                 self._remaining = struct.unpack_from(">L", data[:4])[0]
                 data = data[4:]
-                if  self._remaining == 0:
+                if self._remaining == 0:
                     self._buf.seek(0)
                     if not self.handshake_complete:
                         print("Doing handshake")
@@ -81,7 +81,6 @@ class Unpacker:
 
                     self._msg_bufs.put_nowait(self._buf)
                     self._buf = io.BytesIO()
-
 
     def _read_object(self, schema, buf):
         schema = fastavro.parse_schema(


### PR DESCRIPTION
This is an alternative approach to #92.

Unfortunately, in doing this I discovered a small protocol error in `yaqc` that is hard to work around.

Namely, we do not send the termination Avro null frame during the handshaking process.
This means that for handshaking (and only handshaking) using the null terminator is not 100% correct

This can be corrected for, but introduces a backwards incompatiblity that I would like to work around if we can.


