### PR TITLE
[WIP] handle windows close signals

### DIFF
--- a/yaqd-core/yaqd_core/_is_daemon.py
+++ b/yaqd-core/yaqd_core/_is_daemon.py
@@ -208,24 +208,27 @@ class IsDaemon(ABC):
                 s, lambda s=s: asyncio.create_task(cls.shutdown_all(s, loop))
             )
 
-        cls.__servers = set()
-        for section in config_file:
-            if section == "shared-settings":
-                continue
-            try:
-                config = cls._parse_config(config_file, section, args)
-            except ValueError as e:
-                logger.error(str(e))
-                continue
-            logger.debug(f"Starting {section} with {config}")
-            await cls._start_daemon(section, config, config_filepath)
-
-        while cls.__servers:
-            awaiting = cls.__servers
+        try:
             cls.__servers = set()
-            await asyncio.wait(awaiting)
-            await asyncio.sleep(1)
-        loop.stop()
+            for section in config_file:
+                if section == "shared-settings":
+                    continue
+                try:
+                    config = cls._parse_config(config_file, section, args)
+                except ValueError as e:
+                    logger.error(str(e))
+                    continue
+                logger.debug(f"Starting {section} with {config}")
+                await cls._start_daemon(section, config, config_filepath)
+
+            while cls.__servers:
+                awaiting = cls.__servers
+                cls.__servers = set()
+                await asyncio.wait(awaiting)
+                await asyncio.sleep(1)
+            loop.stop()
+        except KeyboardInterrupt:  # handle windows ctrl+c
+            await cls.shutdown_all(signal.SIGINT, loop)
 
     @classmethod
     async def _start_daemon(cls, name, config, config_filepath):

--- a/yaqd-core/yaqd_core/_is_daemon.py
+++ b/yaqd-core/yaqd_core/_is_daemon.py
@@ -192,13 +192,14 @@ class IsDaemon(ABC):
         # Run the event loop
         try:
             asyncio.run(cls._main(config_filepath, config_file, args))
-        except asyncio.CancelledError:
-            pass
+        except KeyboardInterrupt:
+            asyncio.run(cls.shutdown_all(signal.SIGINT, loop=cls.loop))
 
     @classmethod
     async def _main(cls, config_filepath, config_file, args=None):
         """Parse command line arguments, run event loop."""
         loop = asyncio.get_running_loop()
+        cls.loop = loop
         if sys.platform.startswith("win"):
             signals = ()
         else:
@@ -208,27 +209,24 @@ class IsDaemon(ABC):
                 s, lambda s=s: asyncio.create_task(cls.shutdown_all(s, loop))
             )
 
-        try:
-            cls.__servers = set()
-            for section in config_file:
-                if section == "shared-settings":
-                    continue
-                try:
-                    config = cls._parse_config(config_file, section, args)
-                except ValueError as e:
-                    logger.error(str(e))
-                    continue
-                logger.debug(f"Starting {section} with {config}")
-                await cls._start_daemon(section, config, config_filepath)
+        cls.__servers = set()
+        for section in config_file:
+            if section == "shared-settings":
+                continue
+            try:
+                config = cls._parse_config(config_file, section, args)
+            except ValueError as e:
+                logger.error(str(e))
+                continue
+            logger.debug(f"Starting {section} with {config}")
+            await cls._start_daemon(section, config, config_filepath)
 
-            while cls.__servers:
-                awaiting = cls.__servers
-                cls.__servers = set()
-                await asyncio.wait(awaiting)
-                await asyncio.sleep(1)
-            loop.stop()
-        except KeyboardInterrupt:  # handle windows ctrl+c
-            await cls.shutdown_all(signal.SIGINT, loop)
+        while cls.__servers:
+            awaiting = cls.__servers
+            cls.__servers = set()
+            await asyncio.wait(awaiting)
+            await asyncio.sleep(1)
+        loop.stop()
 
     @classmethod
     async def _start_daemon(cls, name, config, config_filepath):

--- a/yaqd-fakes/yaqd_fakes/_fake_sensor.py
+++ b/yaqd-fakes/yaqd_fakes/_fake_sensor.py
@@ -39,3 +39,10 @@ class FakeSensor(IsSensor, IsDaemon):
             out["measurement_id"] = self._measurement_id
             self._measured = out
             await asyncio.sleep(self._config["update_period"])
+
+    async def aclose(self):
+        await asyncio.sleep(0.1)
+        self.logger.info("finished async close routine")
+
+    def close(self):
+        asyncio.get_running_loop().create_task(self.aclose())


### PR DESCRIPTION
This PR handles windows interrupts so that the daemon close method is reached.

It would be great if windows machines had graceful shutdowns; some daemons don't let go of hardware handles unless their close method is called.  An consequence is closing daemons in foreground is annoying, e.g. you have to close the cmd window, rather than just sending ctrl+c interrupts.  

-  test on windows computers
- make a test for a clean close